### PR TITLE
fix workshopper-jlord dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "license": "BSD-3-Clause",
   "bin": "./pattern-lab.js",
   "dependencies": {
+    "cheerio": "~0.17.0",
     "concat-stream": "~1.2.1",
     "ecstatic": "^0.5.4",
     "glob": "^3.2.11",
     "handlebars": "^2.0.0-alpha.4",
     "marked": "^0.3.2",
     "request": "~2.30.0",
-    "workshopper-jlord": "git@github.com:tjheffner/workshopper.git",
-    "cheerio": "~0.17.0"
+    "workshopper-jlord": "0.0.6"
   }
 }


### PR DESCRIPTION
Hey!

A lot of people have issues installing this workshopper because of the `workshopper-jlord` dependency failing. I replaced that (malformed?) git repository with the version from npm (should be the same I think, seems to work at least).

This should close #10.
